### PR TITLE
Add permissions and usage informations

### DIFF
--- a/src/me/clickpt/easysetspawn/Main.java
+++ b/src/me/clickpt/easysetspawn/Main.java
@@ -53,9 +53,15 @@ public class Main extends JavaPlugin {
 	// -------------------------------------
 	
 	private void registerCommands() {
-		getCommand("setspawn").setExecutor(new SetSpawnCMD());
-		getCommand("spawn").setExecutor(new SpawnCMD());
-		getCommand("easyss").setExecutor(new EasySSCMD());
+		SetSpawnCMD setSpawnCmd = new SetSpawnCMD();
+		SpawnCMD spawnCmd = new SpawnCMD();
+		EasySSCMD easyssCmd = new EasySSCMD();
+		getCommand("setspawn").setExecutor(setSpawnCmd);
+		getCommand("spawn").setExecutor(spawnCmd);
+		getCommand("easyss").setExecutor(easyssCmd);
+		getCommand("setspawn").setTabCompleter(setSpawnCmd);
+		getCommand("spawn").setTabCompleter(spawnCmd);
+		getCommand("easyss").setTabCompleter(easyssCmd);
 	}
 	
 	private void registerListeners() {

--- a/src/me/clickpt/easysetspawn/commands/EasySSCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/EasySSCMD.java
@@ -81,7 +81,7 @@ public class EasySSCMD implements CommandExecutor {
 			}
 		}
 		
-		return false;
+		return true;
 	}
 
 }

--- a/src/me/clickpt/easysetspawn/commands/EasySSCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/EasySSCMD.java
@@ -1,8 +1,13 @@
 package me.clickpt.easysetspawn.commands;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 import me.clickpt.easysetspawn.Main;
@@ -10,7 +15,7 @@ import me.clickpt.easysetspawn.Utils;
 import me.clickpt.easysetspawn.config.Config;
 import me.clickpt.easysetspawn.config.ConfigUtil;
 
-public class EasySSCMD implements CommandExecutor {
+public class EasySSCMD implements CommandExecutor, TabCompleter {
 
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
@@ -82,6 +87,27 @@ public class EasySSCMD implements CommandExecutor {
 		}
 		
 		return true;
+	}
+	
+	@Override
+	public final List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length == 1) {
+			List<String> results = new ArrayList<String>();
+			if (Utils.hasPermission(sender, "help") && "help".startsWith(args[0])) {
+				results.add("help");
+			}
+			if (Utils.hasPermission(sender, "info") && "info".startsWith(args[0])) {
+				results.add("info");
+			}
+			if (Utils.hasPermission(sender, "setdelay") && "setdelay".startsWith(args[0])) {
+				results.add("setdelay");
+			}
+			if (Utils.hasPermission(sender, "reload") && "reload".startsWith(args[0])) {
+				results.add("reload");
+			}
+			return results;
+		}
+		return Collections.emptyList();
 	}
 
 }

--- a/src/me/clickpt/easysetspawn/commands/SetSpawnCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/SetSpawnCMD.java
@@ -32,7 +32,7 @@ public class SetSpawnCMD implements CommandExecutor {
 			p.sendMessage(ConfigUtil.getNoPermission());
 		}
 		
-		return false;
+		return true;
 	}
 
 }

--- a/src/me/clickpt/easysetspawn/commands/SetSpawnCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/SetSpawnCMD.java
@@ -1,9 +1,13 @@
 package me.clickpt.easysetspawn.commands;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 import me.clickpt.easysetspawn.Main;
@@ -11,7 +15,7 @@ import me.clickpt.easysetspawn.Spawn;
 import me.clickpt.easysetspawn.Utils;
 import me.clickpt.easysetspawn.config.ConfigUtil;
 
-public class SetSpawnCMD implements CommandExecutor {
+public class SetSpawnCMD implements CommandExecutor, TabCompleter {
 
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
@@ -33,6 +37,11 @@ public class SetSpawnCMD implements CommandExecutor {
 		}
 		
 		return true;
+	}
+	
+	@Override
+	public final List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		return Collections.emptyList();
 	}
 
 }

--- a/src/me/clickpt/easysetspawn/commands/SpawnCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/SpawnCMD.java
@@ -49,7 +49,7 @@ public class SpawnCMD implements CommandExecutor {
 			sender.sendMessage(ConfigUtil.getNoPermission());
 		}
 		
-		return false;
+		return true;
 	}
 
 }

--- a/src/me/clickpt/easysetspawn/commands/SpawnCMD.java
+++ b/src/me/clickpt/easysetspawn/commands/SpawnCMD.java
@@ -1,9 +1,13 @@
 package me.clickpt.easysetspawn.commands;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 import me.clickpt.easysetspawn.Main;
@@ -11,7 +15,7 @@ import me.clickpt.easysetspawn.Spawn;
 import me.clickpt.easysetspawn.Utils;
 import me.clickpt.easysetspawn.config.ConfigUtil;
 
-public class SpawnCMD implements CommandExecutor {
+public class SpawnCMD implements CommandExecutor, TabCompleter {
 	
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
@@ -50,6 +54,14 @@ public class SpawnCMD implements CommandExecutor {
 		}
 		
 		return true;
+	}
+	
+	@Override
+	public final List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length == 1 && Utils.hasPermission(sender, "teleportothers")) {
+			return null; // Bukkit will list online players.
+		}
+		return Collections.emptyList();
 	}
 
 }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,13 +1,61 @@
 name: EasySetSpawn
 main: me.clickpt.easysetspawn.Main
+description: Simple bukkit plugin for set global spawn with very useful options in config.
 version: 3.2
 author: ClickPT
 website: https://dev.bukkit.org/projects/easysetspawn
 
 commands:
     setspawn:
-     description: Set spawn.
+     description: Set spawn for all players.
+     permission: easysetspawn.setspawn
+     usage: "Usage: /<command>"
     spawn:
      description: Teleport to spawn.
+     permission: easysetspawn.spawn
+     usage: "Usage: /<command> [player]"
     easyss:
      description: General command.
+     usage: "Usage: /<command> | /<command> help/info/reload | /<command> setdelay [seconds]"
+     permission: easysetspawn.help
+
+permissions:
+  easysetspawn.setspawn:
+    description: Allows you to use the command /setspawn
+    default: op
+  easysetspawn.spawn:
+    description: Allows you to use the command /spawn
+    default: true
+  easysetspawn.teleportothers:
+    description: Allows you to teleport other players to spawn
+    default: false
+  easysetspawn.help:
+    description: Allows you to get help with the command /easyss
+    default: op
+    children:
+      easysetspawn.info: true
+      easysetspawn.reload: true
+      easysetspawn.setdelay: true
+  easysetspawn.info:
+    description: Allows you to use the command /easyss info
+    default: op
+  easysetspawn.reload:
+    description: Allows you to use the command /easyss reload
+    default: op
+  easysetspawn.setdelay:
+    description: Allows you to use the command /easyss setdelay
+    default: op
+  easysetspawn.bypassdelay:
+    description: Allows you to bypass the teleportation delay
+    default: false
+  easysetspawn.bypasscmdblock:
+    description: Allows you to bypass block of /spawn command
+    default: false
+  easysetspawn.*:
+    description: Global permission
+    default: false
+    children:
+      easysetspawn.setspawn: true
+      easysetspawn.spawn: true
+      easysetspawn.teleportothers: true
+      easysetspawn.help: true


### PR DESCRIPTION
Change plugin.yml in order to add permissions.
This way, the commands a player cannot execute won't be listed.

Also add some descriptions & tab completion support.