### PR TITLE
Use regexp and actual numbers to check plugin version

### DIFF
--- a/src/me/clickpt/easysetspawn/Main.java
+++ b/src/me/clickpt/easysetspawn/Main.java
@@ -4,6 +4,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -88,6 +91,9 @@ public class Main extends JavaPlugin {
 	}
 	
 	// -------------------------------------
+	
+	private static final Pattern VERSION_SEPARATOR = Pattern.compile(Pattern.quote("."));
+	private static final Pattern VERSION_LOCATE = Pattern.compile("[1-9]+(\\.[0-9]+)*");
 
 	public void checkVersion() throws IOException {
 		if(getConfig().getBoolean("check-version.enabled")) {
@@ -96,13 +102,36 @@ public class Main extends JavaPlugin {
 			URL url = new URL("https://raw.githubusercontent.com/TiagoCN/EasySetSpawn/master/version.txt");
 			BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()));
 			String str;
+			Matcher matcher;
+			int[] remoteVersion = null, localVersion = null;
 
-			if((str = br.readLine()) != null)
-				if(str != null && str.matches(".*[123456789.-].*") && str.length() <= 16)
-					if(!str.equalsIgnoreCase(getPluginVersion()))
-							new_version = true;
+			if((str = br.readLine()) != null) {
+				matcher = VERSION_LOCATE.matcher(str);
+				if (matcher.find()) {
+					str = str.substring(matcher.start(), matcher.end());
+					remoteVersion = VERSION_SEPARATOR.splitAsStream(str).mapToInt(Integer::parseInt).toArray();
+				}
+			}
 
 			br.close();
+			
+			matcher = VERSION_LOCATE.matcher(getPluginVersion());
+			if (matcher.find()) {
+				str = getPluginVersion().substring(matcher.start(), matcher.end());
+				localVersion = VERSION_SEPARATOR.splitAsStream(str).mapToInt(Integer::parseInt).toArray();
+			}
+			
+			if (localVersion == null) return; // Error: could not get my own version ?
+			if (remoteVersion == null) return; // Error: remote version info not available.
+			
+			for (int i = 0; i < Math.max(remoteVersion.length, localVersion.length); ++i) {
+				int remote = (i < remoteVersion.length) ? remoteVersion[i] : 0;
+				int local = (i < localVersion.length) ? localVersion[i] : 0;
+				if (remote > local) {
+					new_version = true;
+					break;
+				} // if local > remote => You have a newer version that the last release, dev build ?
+			}
 			
 			if(new_version) {
 				getLogger().info("Update available!");


### PR DESCRIPTION
Hi (again),
With your last commits (and the fact that you implemented some regexp), I come up with the idea of comparing actual numbers.
I used Regexp to get just the version number ("X", "X.X", "XX.X", "X.X.X", etc...), streams to convert the text to integers and a loop to check each local and remote version numbers against each other.